### PR TITLE
replace httr::GET() with httr::RETRY()

### DIFF
--- a/R/download_kml.R
+++ b/R/download_kml.R
@@ -32,7 +32,7 @@ download_kml <- function(locator) {
   
    for(i in 1:length(to_download)) {
       full_url <- paste(base_url, geo_ref, "kml", to_download[i], sep="/")
-      temp_file <- content(GET(url = full_url), as = "text")
+      temp_file <- content(RETRY(verb = "GET", url = full_url, terminate_on = c(404)), as = "text")
       ###Write file
       to_write<- file(paste(my_path,to_download[i], ".kml", sep=""), open = "w")
       writeLines(temp_file,to_write)

--- a/R/get_climate_data.R
+++ b/R/get_climate_data.R
@@ -40,7 +40,7 @@ get_climate_data <- function(locator,geo_type,type, cvar, start, end){
   
 #  print(full_url)
 
-    res <- GET(full_url)
+    res <- RETRY("GET", full_url, terminate_on = c(404))
   stop_for_status(res)
   raw_data <- try(content(res, as = "text"), silent = TRUE)
   if(sum(grep("unexpected",raw_data)) > 0){

--- a/R/get_ensemble_climate_data.R
+++ b/R/get_ensemble_climate_data.R
@@ -41,7 +41,7 @@ get_ensemble_climate_data <- function(locator,
   data_url <- paste(geo_type, type, "ensemble", cvar, start, end, locator, sep="/")
   extension <- ".json"
   full_url <- paste(base_url, data_url, extension, sep="")
-  raw_data <- try(content(GET(full_url), as="text"), silent=TRUE)
+  raw_data <- try(content(RETRY("GET", full_url, terminate_on = c(404)), as="text"), silent=TRUE)
   data_out <- jsonlite::fromJSON(raw_data)
 #   json <- jsonlite::fromJSON(raw_data, FALSE)
 #   data_out <- plyr::rbind.fill(lapply(json, function(z) {

--- a/R/get_historical_data.R
+++ b/R/get_historical_data.R
@@ -46,7 +46,7 @@ if(geo_type == "basin"){
 data_url <- paste(geo_type,"cru",cvar,time_scale,locator,sep="/")
 extension <- ".json"
 full_url <- paste(base_url,data_url,extension,sep="")
-raw_data <- try(content(GET(full_url),as="text"),silent=T)
+raw_data <- try(content(RETRY("GET", full_url, terminate_on = c(404)),as="text"),silent=T)
 
 if(sum(grep("unexpected",raw_data)) > 0){
   stop(paste("You entered a country for which there is no data. ",locator," is not a country with any data"))


### PR DESCRIPTION
Thanks for this awesome project!

In this PR, I'd like to propose swapping out calls to httr::GET() etc. with httr::RETRY(). This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on chircollab/chircollab20#1 as part of Chicago R Collab, an R 'unconference' in Chicago.